### PR TITLE
Sort the investments from the creation date

### DIFF
--- a/src/data/investments.js
+++ b/src/data/investments.js
@@ -11,7 +11,10 @@ class InvestmentController {
   static async getAllInvestments(token) {
     const user = await decodeToken(token);
     const { id: userId } = user;
-    const investments = await models.Investment.findAll({ where: { userId } });
+    const investments = await models.Investment.findAll({
+      where: { userId },
+      order: [["createdAt", "DESC"]]
+    });
     return investments;
   }
 


### PR DESCRIPTION
## what does this PR do?
- sort the list of investments from the latest 
## how to test the functionality?
- clone the repo and check out this branch `ch-sort-investments-#171691919`
- consume the `GetAllInvesments` query, you should see a list of all investments sorted from the latest. 